### PR TITLE
Add CloudFront invalidation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,3 +20,10 @@ jobs:
         run: |
           aws s3 cp ./index.html s3://com.petersobot/index.html
           aws s3 cp ./resume/index.html s3://com.petersobot/resume/index.html
+      - name: Invalidate CloudFront cache
+        env:
+          CLOUDFRONT_DISTRIBUTION_IDS: ${{ secrets.CLOUDFRONT_DISTRIBUTION_IDS }}
+        run: |
+          for dist in $CLOUDFRONT_DISTRIBUTION_IDS; do
+            aws cloudfront create-invalidation --distribution-id "$dist" --paths "/*"
+          done


### PR DESCRIPTION
## Summary
- invalidate CloudFront distribution after uploading files so changes propagate immediately
- support multiple newline-separated distribution IDs via `CLOUDFRONT_DISTRIBUTION_IDS`

## Testing
- `git status --short`
